### PR TITLE
Fix writing empty files when filename is empty

### DIFF
--- a/flask_store/sqla.py
+++ b/flask_store/sqla.py
@@ -81,7 +81,7 @@ class FlaskStoreType(sqlalchemy.types.TypeDecorator):
             Flask Application configuration
         """
 
-        if not isinstance(value, FileStorage):
+        if not isinstance(value, FileStorage) or not value.filename:
             return None
 
         provider = Provider(value, location=self.location)
@@ -105,6 +105,9 @@ class FlaskStoreType(sqlalchemy.types.TypeDecorator):
         obj
             An instance of the Store Provider class
         """
+
+        if not value:
+            return None
 
         provider = Provider(value, location=self.location)
         return provider


### PR DESCRIPTION
Not sure if this is really the best place to fix this issue, but thought its quite a common scenario:

* If a `FileStorage` object is created from a form, then it may exist but not contain any data (ie. user didn't upload a file), so is surprising when an empty file is created.
* A `Provider` expects a `FileStorage` object, which may not be the case if the sqla column is `nullable`.